### PR TITLE
Updated block explorer to official URL

### DIFF
--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -108,7 +108,7 @@ OptionsDialog::OptionsDialog(QWidget *parent, bool enableWallet) :
         }
     }
 #if QT_VERSION >= 0x040700
-    ui->thirdPartyTxUrls->setPlaceholderText("https://example.com/tx/%s");
+    ui->thirdPartyTxUrls->setPlaceholderText("https://chain.getmynt.io/tx/%s");
 #endif
 
     ui->unit->setModel(new MyntUnits(this));


### PR DESCRIPTION
c.f. title; official block explorer available [here](https://chain.getmynt.io/).